### PR TITLE
Add recursive flag to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ The default location is `/usr/local/bin`.
 
 Here's an example with `xcodebuild`:
     
-    git clone https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
+    git clone --recursive https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
     xcodebuild -project /tmp/xcode-coveralls/xcode-coveralls.xcodeproj -scheme xcode-coveralls DSTROOT=/ SYMROOT=build install
 
 And here's an example with `xctool`:
 
-    git clone https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
+    git clone --recursive https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
     sudo xctool --project /tmp/xcode-coveralls/xcode-coveralls.xcodeproj --scheme xcode-coveralls DSTROOT=/ install
     
 Note that you can use this on Travis builds (for instance in `before_install`) in order to get coverage reports for your project.

--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ The default location is `/usr/local/bin`.
 
 Here's an example with `xcodebuild`:
     
-    git clone --recursive https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
+    git clone --recurse-submodules https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
     xcodebuild -project /tmp/xcode-coveralls/xcode-coveralls.xcodeproj -scheme xcode-coveralls DSTROOT=/ SYMROOT=build install
 
 And here's an example with `xctool`:
 
-    git clone --recursive https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
+    git clone --recurse-submodules https://github.com/macmade/xcode-coveralls.git /tmp/xcode-coveralls
     sudo xctool --project /tmp/xcode-coveralls/xcode-coveralls.xcodeproj --scheme xcode-coveralls DSTROOT=/ install
     
 Note that you can use this on Travis builds (for instance in `before_install`) in order to get coverage reports for your project.


### PR DESCRIPTION
Closes #8 by adding the `--recursive` flag to the installation instructions.